### PR TITLE
Fix: `let` and `const` are allowed only in strict mode.

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -1,3 +1,5 @@
+"use strict"
+
 const bcrypt = require('bcryptjs')
 const deepmerge = require('deepmerge')
 const Sequelize = require('sequelize')

--- a/src/ender.js
+++ b/src/ender.js
@@ -1,3 +1,5 @@
+"use strict"
+
 const deepmerge = require('deepmerge')
 const path = require('path')
 

--- a/src/log.js
+++ b/src/log.js
@@ -1,3 +1,5 @@
+"use strict"
+
 const colors = require('colors/safe')
 
 //


### PR DESCRIPTION
Issue:  running `npm run dev` on apiko-starter failed.

Cause: apiko throws error as we are using `let` and `const` outside of strict mode.

