### PR TITLE
Empty handler sends 501

### DIFF
--- a/src/empty-handler.js
+++ b/src/empty-handler.js
@@ -1,0 +1,7 @@
+'use strict'
+const { EmptyHandler } = require('./errors')
+module.exports = function deleteUsers (req, res, next) {
+  const e = new EmptyHandler()
+  res.body = res.setError(e.statusCode, e.message, e.errorCode)
+  next()
+}

--- a/src/ender.js
+++ b/src/ender.js
@@ -52,10 +52,12 @@ module.exports = function (g) {
               }
             }
           } else {
-            g.log.w(0, 'Endpoint ', i, 'is registered with no handler! (2)')
+            g.log.w(2, 'Endpoint ', i, 'is registered with no handler! (2)')
+            this.addHandling(i, require('./empty-handler'))
           }
         } else {
-          g.log.w(0, 'Endpoint ', i, 'is registered with no handler! (1)')
+          g.log.w(2, 'Endpoint ', i, 'is registered with no handler! (1)')
+          this.addHandling(i, require('./empty-handler'))
         }
 
         // a checker that eventually sends the response if nothing else in the chain does

--- a/src/errors.js
+++ b/src/errors.js
@@ -44,10 +44,26 @@ class NoAdminUserWithId extends Error {
   }
 }
 
+class EmptyHandler extends Error {
+  constructor () {
+    super()
+    this.message = 'The handler of this endpoint is empty'
+    this.name = 'EmptyHandler'
+    this.errorCode = 50
+    this.statusCode = 501
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, EmptyHandler)
+    } else {
+      this.stack = (new Error()).stack
+    }
+  }
+}
+
 let ret = {
-  NoUserWithIdError: NoUserWithIdError,
-  IncorrectCurrentPasswordError: IncorrectCurrentPasswordError,
-  NoAdminUserWithId: NoAdminUserWithId
+  NoUserWithIdError,
+  IncorrectCurrentPasswordError,
+  NoAdminUserWithId,
+  EmptyHandler
 }
 
 module.exports = ret

--- a/test/empty-handler.js
+++ b/test/empty-handler.js
@@ -1,0 +1,31 @@
+'use strict'
+let rp = require('request-promise')
+let expect = require('chai').expect
+
+describe('requests with no handler', () => {
+  let apiko
+  let apikoOpts
+  beforeEach(async () => {
+    const config = { port: 5000, verbosity: 0 }
+    apiko = await require('../').run(config)
+    apikoOpts = require('../apiko.json')
+  })
+
+  afterEach(() => {
+    apiko.httpClose()
+  })
+  it('Empty DELETE /users handler for lvl handler should return 501', async () => {
+    const response = await rp(
+      {
+        method: 'DELETE',
+        uri: 'http://127.0.0.1:5000/users/',
+        body: {
+          secret: apikoOpts.secret
+        },
+        resolveWithFullResponse: true,
+        json: true,
+        simple: false
+      })
+    expect(response.statusCode).to.equal(501)
+  })
+})


### PR DESCRIPTION
#46
Empty handler return 501 by default.
Lower lvl of bug log for empty handler from 0 - critical to 2 - error