### PR TITLE
Revert "Custom handlers loads before all others"

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,8 +60,8 @@ module.exports = {
     return g.data.sync()
       .then(() => {
         g.app.httpClose()
-        g.app.loaded()
         g.ender.reload()
+        g.app.loaded()
         return g.app.httpListen()
       })
   },


### PR DESCRIPTION
Reverts apiko-rest-api/apiko#75
Custom user handler should be executed after generic/core handlers