### PR TITLE
Fixed next call firing bug before user is created, inside users/post.js.

### DIFF
--- a/src/users/post.js
+++ b/src/users/post.js
@@ -18,7 +18,5 @@ module.exports = function (req, res, next) {
     }
   }).catch(error => {
     g.log.w(1, 'Registration error:', error)
-  })
-
-  next()
+  }).then(next)
 }


### PR DESCRIPTION
When registering a new user, the next() call is called before the user is created. The function g.store.users.findOrCreate(defaults) is called and before it returns a promise or not, next() is called. I ran into trouble when registering a user & immediately calling POST /users/login. When registering a user it sends me 200 OK but it didn't finish creating the user. When I immediately called the user login, it doesn't find it. So the solution would be to call next() after g.store.users.findOrCreate(defaults) is done or throws an error.