### PR TITLE
Made role of user registration to be not required by default

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -91,6 +91,9 @@ module.exports = {
         password: {
           required: true,
           regex: '^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d).{8,18}$'
+        },
+        role: {
+          required: false
         }
       },
       handlers: {


### PR DESCRIPTION
When creating a user, role is required by default. I don't think that should be the case. When role is not sent with the request, it should put role = '' inside the apiko server database.