### PR TITLE
Order and group parameters in GET request will be parsed through JSON.

### DIFF
--- a/src/generic/get.js
+++ b/src/generic/get.js
@@ -36,11 +36,11 @@ module.exports = function genericGet (req, res, next) {
   }
 
   if (req.all.order) {
-    opts.order = req.all.order
+    opts.order = JSON.parse(req.all.order)
   }
 
   if (req.all.group) {
-    opts.group = req.all.group
+    opts.group = JSON.parse(req.all.group)
   }
 
   g.store[collection].findAll(opts).then(records => {


### PR DESCRIPTION
It's needed for complex ordering / grouping like:
[['createdAt', 'DESC']]

Signed-off-by: Ilya Labacheuski <ilya.labacheuski@gmail.com>